### PR TITLE
1234 restore drop down icons in timeseries wizard

### DIFF
--- a/web-server/components/SlycatNumberInput.tsx
+++ b/web-server/components/SlycatNumberInput.tsx
@@ -1,63 +1,65 @@
-'use strict';
-import * as React from 'react';
+import * as React from "react";
 
 /**
  */
 export interface SlycatNumberInputProps {
-  value: number
-  style?: any
-  label: string
-  callBack: Function
-  id?: string
-  warning?: string
+  value: number;
+  style?: any;
+  label: string;
+  callBack: Function;
+  id?: string;
+  warning?: string;
 }
 
 /**
  * not used
  */
 export interface SlycatNumberInputState {
-  value: number
+  value: number;
 }
 /**
  * class that creates a a form with checkboxes
  * some other process
  */
-export default class SlycatNumberInput extends React.Component<SlycatNumberInputProps, SlycatNumberInputState> {
+export default class SlycatNumberInput extends React.Component<
+  SlycatNumberInputProps,
+  SlycatNumberInputState
+> {
   /**
    * not used
    */
-  public constructor(props:SlycatNumberInputProps) {
-    super(props)
+  public constructor(props: SlycatNumberInputProps) {
+    super(props);
     this.state = {
-      value: props.value
-    }
+      value: props.value,
+    };
   }
 
-  onValueChange = (value:number) => {
+  onValueChange = (value: number) => {
     // localStorage.setItem("slycat-remote-controls-username", value);
-    if(value === '') {
+    if (value === "") {
       value = 1;
     }
-    this.setState({value: value});
+    this.setState({ value: value });
     this.props.callBack(value);
   };
 
-  public render () {
+  public render() {
     return (
-    <div className='form-group row mb-3'>
-        <label className='col-sm-2 col-form-label'>{this.props.label}</label>
-        <div className='col-sm-9'>
+      <div className="form-group row mb-3">
+        <label className="col-sm-2 col-form-label">{this.props.label}</label>
+        <div className="col-sm-9">
           <input
             id={this.props.id}
-            className='form-control' type='number' min={1}
+            className="form-control"
+            type="number"
+            min={1}
             value={this.state.value}
-            onChange={(e)=>this.onValueChange(e.target.value)}
+            onChange={(e) => this.onValueChange(e.target.value)}
           />
-          <div className="invalid-feedback">
-            {this.props.warning}
-          </div>
+          <div className="invalid-feedback">{this.props.warning}</div>
         </div>
-    </div>
+      </div>
     );
   }
 }

--- a/web-server/components/SlycatNumberInput.tsx
+++ b/web-server/components/SlycatNumberInput.tsx
@@ -45,20 +45,23 @@ export default class SlycatNumberInput extends React.Component<
   };
 
   public render() {
+    const inputId = this.props.id || `number-input-${Math.random().toString(36).substr(2, 9)}`;
+    
     return (
-      <div className="form-group row mb-3">
-        <label className="col-sm-2 col-form-label">{this.props.label}</label>
-        <div className="col-sm-9">
-          <input
-            id={this.props.id}
-            className="form-control"
-            type="number"
-            min={1}
-            value={this.state.value}
-            onChange={(e) => this.onValueChange(e.target.value)}
-          />
+      <div className="form-floating mb-3">
+        <input
+          id={inputId}
+          className={`form-control ${this.props.warning ? 'is-invalid' : ''}`}
+          type="number"
+          min={1}
+          value={this.state.value}
+          onChange={(e) => this.onValueChange(e.target.value)}
+          placeholder={this.props.label}
+        />
+        <label htmlFor={inputId}>{this.props.label}</label>
+        {this.props.warning && (
           <div className="invalid-feedback">{this.props.warning}</div>
-        </div>
+        )}
       </div>
     );
   }

--- a/web-server/components/SlycatSelector.tsx
+++ b/web-server/components/SlycatSelector.tsx
@@ -56,27 +56,29 @@ export default class SlycatSelector extends React.Component<
   };
 
   public render() {
+    const selectId = `select-${Math.random().toString(36).substr(2, 9)}`;
+    
     return (
-      <div className="form-group row">
-        <label className="col-sm-2 col-form-label">{this.props.label}</label>
-        <div className="col-sm-9">
-          {this.props.disabled === true ? (
-            <select
-              className="form-control"
-              onChange={(e) => this.props.onSelectCallBack(e.target.value)}
-              disabled
-            >
-              {this.getOptions()}
-            </select>
-          ) : (
-            <select
-              className="form-control"
-              onChange={(e) => this.props.onSelectCallBack(e.target.value)}
-            >
-              {this.getOptions()}
-            </select>
-          )}
-        </div>
+      <div className="form-floating mb-3">
+        {this.props.disabled === true ? (
+          <select
+            id={selectId}
+            className="form-select"
+            onChange={(e) => this.props.onSelectCallBack(e.target.value)}
+            disabled
+          >
+            {this.getOptions()}
+          </select>
+        ) : (
+          <select
+            id={selectId}
+            className="form-select"
+            onChange={(e) => this.props.onSelectCallBack(e.target.value)}
+          >
+            {this.getOptions()}
+          </select>
+        )}
+        <label htmlFor={selectId}>{this.props.label}</label>
       </div>
     );
   }

--- a/web-server/components/SlycatSelector.tsx
+++ b/web-server/components/SlycatSelector.tsx
@@ -1,16 +1,15 @@
-'use strict';
-import * as React from 'react';
+import * as React from "react";
 
 /**
  * @param {onSelectCallBack} callback when selected
  * @param {options} option list
  * @param {label} label for the dropdown
  */
-export interface SlycatSelectorProps { 
-  onSelectCallBack: Function
-  options: Option[]
-  label: string
-  disabled?: boolean
+export interface SlycatSelectorProps {
+  onSelectCallBack: Function;
+  options: Option[];
+  label: string;
+  disabled?: boolean;
 }
 
 /**
@@ -19,24 +18,26 @@ export interface SlycatSelectorProps {
  * @interface option
  */
 export interface Option {
-  text: string
-  value: string
+  text: string;
+  value: string;
 }
 
 /**
  * not used
  */
-export interface SlycatSelectorState {
-}
+export interface SlycatSelectorState {}
 /**
  * class that creates a dropdown with values given in options prop
  */
-export default class SlycatSelector extends React.Component<SlycatSelectorProps, SlycatSelectorState> {
+export default class SlycatSelector extends React.Component<
+  SlycatSelectorProps,
+  SlycatSelectorState
+> {
   /**
    * not used
    */
   public constructor(props: SlycatSelectorProps) {
-    super(props)
+    super(props);
     this.state = {};
   }
 
@@ -45,28 +46,38 @@ export default class SlycatSelector extends React.Component<SlycatSelectorProps,
    *
    * @memberof SlycatSelector
    */
-  getOptions = (): JSX.Element[]=> {
-    const jsxOptions = this.props.options.map((option, i) => <option key={i} value={option.value}>{option.text}</option>);
+  getOptions = (): JSX.Element[] => {
+    const jsxOptions = this.props.options.map((option, i) => (
+      <option key={i} value={option.value}>
+        {option.text}
+      </option>
+    ));
     return jsxOptions;
-  }
+  };
 
-  public render () {
+  public render() {
     return (
       <div className="form-group row">
-        <label className="col-sm-2 col-form-label">
-          {this.props.label}
-        </label>
-        <div className='col-sm-9'>
-          {this.props.disabled === true ?          
-          <select className="form-control" onChange={(e)=>this.props.onSelectCallBack(e.target.value)} disabled>
-            {this.getOptions()}
-          </select>
-          :
-          <select className="form-control" onChange={(e)=>this.props.onSelectCallBack(e.target.value)} >
-          {this.getOptions()}
-        </select> }          
+        <label className="col-sm-2 col-form-label">{this.props.label}</label>
+        <div className="col-sm-9">
+          {this.props.disabled === true ? (
+            <select
+              className="form-control"
+              onChange={(e) => this.props.onSelectCallBack(e.target.value)}
+              disabled
+            >
+              {this.getOptions()}
+            </select>
+          ) : (
+            <select
+              className="form-control"
+              onChange={(e) => this.props.onSelectCallBack(e.target.value)}
+            >
+              {this.getOptions()}
+            </select>
+          )}
         </div>
       </div>
-    )
+    );
   }
 }

--- a/web-server/components/SlycatTextInput.tsx
+++ b/web-server/components/SlycatTextInput.tsx
@@ -1,62 +1,63 @@
-'use strict';
-import * as React from 'react';
+import * as React from "react";
 
 /**
  */
 export interface SlycatTextInputProps {
-  onChange?: Function
-  value: string
-  style?: any
-  label: string
-  callBack: Function
-  id?: string
-  warning?: string
+  onChange?: Function;
+  value: string;
+  style?: any;
+  label: string;
+  callBack: Function;
+  id?: string;
+  warning?: string;
 }
 
 /**
  * not used
  */
 export interface SlycatTextInputState {
-  value: string
+  value: string;
 }
 /**
  * class that creates a a form with checkboxes
  * some other process
  */
-export default class SlycatTextInput extends React.Component<SlycatTextInputProps, SlycatTextInputState> {
+export default class SlycatTextInput extends React.Component<
+  SlycatTextInputProps,
+  SlycatTextInputState
+> {
   /**
    * not used
    */
-  public constructor(props:SlycatTextInputProps) {
-    super(props)
+  public constructor(props: SlycatTextInputProps) {
+    super(props);
     this.state = {
-      value: props.value
-    }
+      value: props.value,
+    };
   }
 
-  onValueChange = (value:string) => {
+  onValueChange = (value: string) => {
     // localStorage.setItem("slycat-remote-controls-username", value);
     // this.setState({value: value});
-    this.setState({value:value});
+    this.setState({ value: value });
     this.props.callBack(value);
   };
 
-  public render () {
+  public render() {
     return (
-    <div className='form-group row mb-3'>
-        <label className='col-sm-2 col-form-label'>{this.props.label}</label>
-        <div className='col-sm-9'>
+      <div className="form-group row mb-3">
+        <label className="col-sm-2 col-form-label">{this.props.label}</label>
+        <div className="col-sm-9">
           <input
             id={this.props.id}
-            className='form-control' type='text'
+            className="form-control"
+            type="text"
             value={this.state.value}
-            onChange={(e)=>this.onValueChange(e.target.value)}
-            />
-            <div className="invalid-feedback">
-              {this.props.warning}
-            </div>
+            onChange={(e) => this.onValueChange(e.target.value)}
+          />
+          <div className="invalid-feedback">{this.props.warning}</div>
         </div>
-    </div>
+      </div>
     );
   }
 }

--- a/web-server/components/SlycatTextInput.tsx
+++ b/web-server/components/SlycatTextInput.tsx
@@ -44,19 +44,22 @@ export default class SlycatTextInput extends React.Component<
   };
 
   public render() {
+    const inputId = this.props.id || `input-${Math.random().toString(36).substr(2, 9)}`;
+    
     return (
-      <div className="form-group row mb-3">
-        <label className="col-sm-2 col-form-label">{this.props.label}</label>
-        <div className="col-sm-9">
-          <input
-            id={this.props.id}
-            className="form-control"
-            type="text"
-            value={this.state.value}
-            onChange={(e) => this.onValueChange(e.target.value)}
-          />
+      <div className="form-floating mb-3">
+        <input
+          id={inputId}
+          className={`form-control ${this.props.warning ? 'is-invalid' : ''}`}
+          type="text"
+          value={this.state.value}
+          onChange={(e) => this.onValueChange(e.target.value)}
+          placeholder={this.props.label}
+        />
+        <label htmlFor={inputId}>{this.props.label}</label>
+        {this.props.warning && (
           <div className="invalid-feedback">{this.props.warning}</div>
-        </div>
+        )}
       </div>
     );
   }

--- a/web-server/components/SlycatTimeInput.tsx
+++ b/web-server/components/SlycatTimeInput.tsx
@@ -55,28 +55,41 @@ export default class SlycatTimeInput extends React.Component<
   };
 
   public render() {
+    const hoursId = `hours-${Math.random().toString(36).substr(2, 9)}`;
+    const minutesId = `minutes-${Math.random().toString(36).substr(2, 9)}`;
+
     return (
-      <div className="form-group row mb-3">
-        <label className="col-sm-2 col-form-label">{this.props.label}</label>
-        <div className="col-sm-2">
-          <input
-            className="form-control"
-            type="number"
-            min={0}
-            value={this.state.hours}
-            onChange={(e) => this.onHourChange(e.target.value)}
-          />
-          Hours
-        </div>
-        <div className="col-sm-2">
-          <input
-            className="form-control"
-            type="number"
-            min={0}
-            value={this.state.minutes}
-            onChange={(e) => this.onMinuteChange(e.target.value)}
-          />
-          Minutes
+      <div className="mb-3">
+        <div className="mb-2">{this.props.label}</div>
+        <div className="row g-2">
+          <div className="col">
+            <div className="form-floating">
+              <input
+                id={hoursId}
+                className="form-control"
+                type="number"
+                min={0}
+                value={this.state.hours}
+                onChange={(e) => this.onHourChange(e.target.value)}
+                placeholder="Hours"
+              />
+              <label htmlFor={hoursId}>Hours</label>
+            </div>
+          </div>
+          <div className="col">
+            <div className="form-floating">
+              <input
+                id={minutesId}
+                className="form-control"
+                type="number"
+                min={0}
+                value={this.state.minutes}
+                onChange={(e) => this.onMinuteChange(e.target.value)}
+                placeholder="Minutes"
+              />
+              <label htmlFor={minutesId}>Minutes</label>
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/web-server/components/SlycatTimeInput.tsx
+++ b/web-server/components/SlycatTimeInput.tsx
@@ -1,77 +1,84 @@
-'use strict';
-import * as React from 'react';
+import * as React from "react";
 
 /**
  */
 export interface SlycatTimeInputProps {
-  hours: number
-  minutes: number
-  minCallBack: Function
-  hourCallBack: Function
-  label: string
+  hours: number;
+  minutes: number;
+  minCallBack: Function;
+  hourCallBack: Function;
+  label: string;
 }
 
 /**
  * not used
  */
 export interface SlycatTimeInputState {
-  hours: number
-  minutes: number
+  hours: number;
+  minutes: number;
 }
 /**
  * class that creates a a form with checkboxes
  * some other process
  */
-export default class SlycatTimeInput extends React.Component<SlycatTimeInputProps, SlycatTimeInputState> {
+export default class SlycatTimeInput extends React.Component<
+  SlycatTimeInputProps,
+  SlycatTimeInputState
+> {
   /**
    * not used
    */
-  public constructor(props:SlycatTimeInputProps) {
-    super(props)
+  public constructor(props: SlycatTimeInputProps) {
+    super(props);
     this.state = {
       hours: props.hours,
-      minutes: props.minutes
-    }
+      minutes: props.minutes,
+    };
   }
 
   onHourChange = (value) => {
     // localStorage.setItem("slycat-remote-controls-username", value);
     // this.setState({value: value});
-    if (value === '') {
+    if (value === "") {
       value = 0;
     }
-    this.setState({hours:value});
+    this.setState({ hours: value });
     this.props.hourCallBack(value);
   };
 
   onMinuteChange = (value) => {
-    if (value === '') {
+    if (value === "") {
       value = 0;
     }
-    this.setState({minutes:value});
+    this.setState({ minutes: value });
     this.props.minCallBack(value);
-  }
+  };
 
-  public render () {
+  public render() {
     return (
-    <div className='form-group row mb-3'>
-        <label className='col-sm-2 col-form-label'>{this.props.label}</label>
-        <div className='col-sm-2'>
+      <div className="form-group row mb-3">
+        <label className="col-sm-2 col-form-label">{this.props.label}</label>
+        <div className="col-sm-2">
           <input
-            className='form-control' type='number' min={0}
+            className="form-control"
+            type="number"
+            min={0}
             value={this.state.hours}
-            onChange={(e)=>this.onHourChange(e.target.value)}
-            />
-            Hours
+            onChange={(e) => this.onHourChange(e.target.value)}
+          />
+          Hours
         </div>
-        <div className='col-sm-2'>
-          <input className='form-control' type='number' min={0}
+        <div className="col-sm-2">
+          <input
+            className="form-control"
+            type="number"
+            min={0}
             value={this.state.minutes}
-            onChange={(e)=>this.onMinuteChange(e.target.value)}
-            />
-            Minutes
+            onChange={(e) => this.onMinuteChange(e.target.value)}
+          />
+          Minutes
         </div>
-    </div>
+      </div>
     );
   }
 }

--- a/web-server/plugins/slycat-timeseries-model/plugin-components/HPCParametersTab.tsx
+++ b/web-server/plugins/slycat-timeseries-model/plugin-components/HPCParametersTab.tsx
@@ -24,11 +24,15 @@ interface HPCParametersTabProps {
 function HPCParametersTab(props: HPCParametersTabProps) {
   return (
     <div>
-      <div className="form-group row mb-3">
-        <label className="col-sm-2 col-form-label">Job Host&nbsp;&nbsp;</label>
-        <div className="col-sm-9">
-          <input className="form-control" value={props.hostName} disabled></input>
-        </div>
+      <div className="form-floating mb-3">
+        <input 
+          id="job-host"
+          className="form-control" 
+          value={props.hostName} 
+          disabled
+          placeholder="Job Host"
+        />
+        <label htmlFor="job-host">Job Host</label>
       </div>
       <SlycatTextInput
         id={"account-id"}

--- a/web-server/plugins/slycat-timeseries-model/plugin-components/HPCParametersTab.tsx
+++ b/web-server/plugins/slycat-timeseries-model/plugin-components/HPCParametersTab.tsx
@@ -25,10 +25,10 @@ function HPCParametersTab(props: HPCParametersTabProps) {
   return (
     <div>
       <div className="form-floating mb-3">
-        <input 
+        <input
           id="job-host"
-          className="form-control" 
-          value={props.hostName} 
+          className="form-control"
+          value={props.hostName}
           disabled
           placeholder="Job Host"
         />

--- a/web-server/plugins/slycat-timeseries-model/plugin-components/HPCParametersTab.tsx
+++ b/web-server/plugins/slycat-timeseries-model/plugin-components/HPCParametersTab.tsx
@@ -1,77 +1,75 @@
-'use strict';
-import * as React from 'react';
-import SlycatTextInput from 'components/SlycatTextInput.tsx';
-import SlycatTimeInput from 'components/SlycatTimeInput.tsx';
-import SlycatNumberInput from 'components/SlycatNumberInput.tsx';
+import * as React from "react";
+import SlycatTextInput from "components/SlycatTextInput";
+import SlycatTimeInput from "components/SlycatTimeInput";
+import SlycatNumberInput from "components/SlycatNumberInput";
 
 interface HPCParametersTabProps {
-    accountId: string
-    hostName: string
-    partition: string
-    numNodes: number
-    cores: number
-    jobHours: number
-    jobMin: number
-    workDir: string
-    accountIdCallback: Function
-    partitionCallback: Function
-    nodesCallback: Function
-    coresCallback: Function
-    hoursCallback: Function
-    minutesCallback: Function
-    workDirCallback: Function
+  accountId: string;
+  hostName: string;
+  partition: string;
+  numNodes: number;
+  cores: number;
+  jobHours: number;
+  jobMin: number;
+  workDir: string;
+  accountIdCallback: Function;
+  partitionCallback: Function;
+  nodesCallback: Function;
+  coresCallback: Function;
+  hoursCallback: Function;
+  minutesCallback: Function;
+  workDirCallback: Function;
 }
 
 function HPCParametersTab(props: HPCParametersTabProps) {
-
-    return (
+  return (
     <div>
-        <div className="form-group row mb-3">
-            <label className="col-sm-2 col-form-label">Job Host&nbsp;&nbsp;</label>
-            <div className="col-sm-9">
-                <input className="form-control" value={props.hostName} disabled></input>
-            </div>
+      <div className="form-group row mb-3">
+        <label className="col-sm-2 col-form-label">Job Host&nbsp;&nbsp;</label>
+        <div className="col-sm-9">
+          <input className="form-control" value={props.hostName} disabled></input>
         </div>
-        <SlycatTextInput
-            id={"account-id"}
-            label={"Account ID"}
-            value={props.accountId ? props.accountId : ''}
-            warning={"Please enter an account ID."}
-            callBack={props.accountIdCallback}
-        />
-        <SlycatTextInput
-            id={"partition"}
-            label={"Partition/Queue"}
-            value={props.partition ? props.partition : ''}
-            warning={"Please enter a partition/batch."}
-            callBack={props.partitionCallback}
-        />
-        <SlycatNumberInput
-            label={'Number of nodes'}
-            value={props.numNodes ? props.numNodes : 1}
-            callBack={props.nodesCallback}
-        />
-        <SlycatNumberInput
-            label={'Cores'}
-            value={props.cores ? props.cores : 2}
-            callBack={props.coresCallback}
-        />
-        <SlycatTimeInput
-            label={'Requested Job Time'}
-            hours={props.jobHours ? props.jobHours : 0}
-            minutes={props.jobMin ? props.jobMin : 30}
-            minCallBack={props.minutesCallback}
-            hourCallBack={props.hoursCallback}
-        />
-        <SlycatTextInput
-            id={"work-dir"}
-            label={"Working Directory"}
-            value={props.workDir ? props.workDir : ''}
-            warning={"Please enter a working directory."}
-            callBack={props.workDirCallback}
-        />
+      </div>
+      <SlycatTextInput
+        id={"account-id"}
+        label={"Account ID"}
+        value={props.accountId ? props.accountId : ""}
+        warning={"Please enter an account ID."}
+        callBack={props.accountIdCallback}
+      />
+      <SlycatTextInput
+        id={"partition"}
+        label={"Partition/Queue"}
+        value={props.partition ? props.partition : ""}
+        warning={"Please enter a partition/batch."}
+        callBack={props.partitionCallback}
+      />
+      <SlycatNumberInput
+        label={"Number of nodes"}
+        value={props.numNodes ? props.numNodes : 1}
+        callBack={props.nodesCallback}
+      />
+      <SlycatNumberInput
+        label={"Cores"}
+        value={props.cores ? props.cores : 2}
+        callBack={props.coresCallback}
+      />
+      <SlycatTimeInput
+        label={"Requested Job Time"}
+        hours={props.jobHours ? props.jobHours : 0}
+        minutes={props.jobMin ? props.jobMin : 30}
+        minCallBack={props.minutesCallback}
+        hourCallBack={props.hoursCallback}
+      />
+      <SlycatTextInput
+        id={"work-dir"}
+        label={"Working Directory"}
+        value={props.workDir ? props.workDir : ""}
+        warning={"Please enter a working directory."}
+        callBack={props.workDirCallback}
+      />
     </div>
-    );
+  );
 }
 
-export default HPCParametersTab
+export default HPCParametersTab;

--- a/web-server/plugins/slycat-timeseries-model/plugin-components/ModelNamingTab.tsx
+++ b/web-server/plugins/slycat-timeseries-model/plugin-components/ModelNamingTab.tsx
@@ -1,6 +1,6 @@
-import SlycatSelector from 'components/SlycatSelector.tsx';
-import SlycatTextInput from 'components/SlycatTextInput.tsx';
-import * as React from 'react';
+import SlycatSelector from "components/SlycatSelector";
+import SlycatTextInput from "components/SlycatTextInput";
+import * as React from "react";
 
 interface ModelNamingTabProps {
   nameCallback: Function;

--- a/web-server/plugins/slycat-timeseries-model/plugin-components/RemoteLoginTab.tsx
+++ b/web-server/plugins/slycat-timeseries-model/plugin-components/RemoteLoginTab.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import SlycatFormRadioCheckbox from "components/SlycatFormRadioCheckbox.tsx";
-import SlycatRemoteControls from "components/SlycatRemoteControls.jsx";
+import SlycatFormRadioCheckbox from "components/SlycatFormRadioCheckbox";
+import SlycatRemoteControls from "components/SlycatRemoteControls";
 
 interface RemoteLoginTabProps {
   checked: string;
@@ -35,10 +35,7 @@ function RemoteLoginTab(props: RemoteLoginTabProps) {
       <div className="alert alert-primary" role="alert">
         This Host or HPC system is also where your job will be submitted.
       </div>
-      <SlycatRemoteControls
-        loadingData={props.loadingData}
-        callBack={props.callBack}
-      />
+      <SlycatRemoteControls loadingData={props.loadingData} callBack={props.callBack} />
     </div>
   );
 }


### PR DESCRIPTION
I converted the remaining timeseries wizard components to use Bootstrap 5 floating labels:
https://getbootstrap.com/docs/5.3/forms/floating-labels/

This is the new style I've been using across Slycat since it simplifies the UI and gets rid of the multi-column layouts we were using in the past (where labels could be cut off or forced to wrap).