### PR TITLE
Reformatting Timeseries Y Axis

### DIFF
--- a/web-server/plugins/slycat-timeseries-model/js/timeseries-waveformplot.js
+++ b/web-server/plugins/slycat-timeseries-model/js/timeseries-waveformplot.js
@@ -270,7 +270,7 @@ $.widget("timeseries.waveformplot", {
 
     this.x = d3.scale.linear().domain([x_min, x_max]).range([0, this.diagram_width]);
 
-    this.y = d3.scale.linear().domain([y_max, y_min]).range([0, this.diagram_height]);
+    this.y = d3.scale.linear().domain([y_max, y_min]).range([0, this.diagram_height]).nice();
 
     this.x_axis = d3.svg.axis().scale(this.x).orient("bottom");
     this.x_axis_layer
@@ -284,7 +284,7 @@ $.widget("timeseries.waveformplot", {
       )
       .call(this.x_axis);
 
-    this.y_axis = d3.svg.axis().scale(this.y).orient("left");
+    this.y_axis = d3.svg.axis().scale(this.y).orient("left").tickFormat(d3.format(".2g"));
     this.y_axis_layer
       .attr(
         "transform",


### PR DESCRIPTION
Includes top number on the y axis labels, and switches to scientific notation when the y axis values have 5 digits or more. Closes #1286