### PR TITLE
refactor: replace hardcoded 'Index' or 'Row' with COLUMN_LABELS.index…

### DIFF
--- a/web-server/plugins/slycat-cca/js/ui.js
+++ b/web-server/plugins/slycat-cca/js/ui.js
@@ -52,6 +52,7 @@ import {
   setBarplotHeight,
   setBarplotWidth,
 } from "./actions";
+import { COLUMN_LABELS } from "utils/ui-labels";
 
 // Wait for document ready
 $(document).ready(function () {
@@ -276,7 +277,7 @@ $(document).ready(function () {
       client.get_model_table_metadata({
         mid: redux_state_tree.derived.model_id,
         aid: "data-table",
-        index: "Index",
+        index: encodeURIComponent(COLUMN_LABELS.index),
         success: function (table_metadata) {
           redux_state_tree.derived.table_metadata = table_metadata;
           if (redux_state_tree.variable_selected === undefined) {

--- a/web-server/plugins/slycat-parameter-image/js/ui.js
+++ b/web-server/plugins/slycat-parameter-image/js/ui.js
@@ -106,6 +106,7 @@ import {
 import React from "react";
 import { createRoot } from "react-dom/client";
 import PSControlsBar from "./Components/PSControlsBar";
+import { COLUMN_LABELS } from "utils/ui-labels";
 
 let table_metadata = null;
 
@@ -366,7 +367,7 @@ $(document).ready(function () {
           }
 
           // Adding Index column
-          table_metadata["column-names"].push("Row");
+          table_metadata["column-names"].push(COLUMN_LABELS.index);
           table_metadata["column-types"].push("int64");
 
           filter_manager.set_table_metadata(table_metadata);

--- a/web-server/plugins/slycat-timeseries-model/js/apiSlice.ts
+++ b/web-server/plugins/slycat-timeseries-model/js/apiSlice.ts
@@ -1,6 +1,7 @@
 // Import the RTK Query methods from the React-specific entry point
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import api_root from "js/slycat-api-root";
+import { COLUMN_LABELS } from "utils/ui-labels";
 
 // Define our single API slice object
 export const apiSlice = createApi({
@@ -16,7 +17,7 @@ export const apiSlice = createApi({
       query: (modelId) => `models/${modelId}`,
     }),
     getTableMetadata: builder.query({
-      query: (modelId) => `models/${modelId}/tables/inputs/arrays/0/metadata?index=Index`,
+      query: (modelId) => `models/${modelId}/tables/inputs/arrays/0/metadata?index=${encodeURIComponent(COLUMN_LABELS.index)}`,
     }),
     getClusters: builder.query({
       query: (modelId) => `models/${modelId}/files/clusters`,

--- a/web-server/plugins/slycat-timeseries-model/js/timeseries-table.js
+++ b/web-server/plugins/slycat-timeseries-model/js/timeseries-table.js
@@ -435,76 +435,6 @@ $.widget("timeseries.table", {
 
     self.onDataLoaded = new SlickEvent();
 
-    self.get_indices_old = function (sortedUnsorted, rows, callback, asynchronous) {
-      if (asynchronous != false) asynchronous = true;
-
-      if (rows.length == 0) {
-        callback([]);
-        return;
-      }
-
-      var sort = "";
-      if (self.sort_column !== null && self.sort_order !== null)
-        sort = "&sort=" + self.sort_column + ":" + self.sort_order;
-
-      var row_string = "";
-      for (var i = 0; i < rows.length; ++i) {
-        row_string += rows[i];
-        break;
-      }
-      for (var i = 1; i < rows.length; ++i) {
-        row_string += ",";
-        row_string += rows[i];
-      }
-
-      // XMLHttpRequest does not support synchronous retrieval with arraybuffer, so falling back to ajax with no arraybuffer for initial synchronous sorted table filter retrieval.
-      if (asynchronous) {
-        var request = new XMLHttpRequest();
-        request.open(
-          "GET",
-          self.api_root +
-            "models/" +
-            self.mid +
-            "/tables/" +
-            self.aid +
-            "/arrays/0/" +
-            sortedUnsorted +
-            "-indices?rows=" +
-            row_string +
-            "&index=Index&byteorder=" +
-            (chunker.is_little_endian() ? "little" : "big") +
-            sort,
-        );
-        request.responseType = "arraybuffer";
-        request.callback = callback;
-        request.onload = function (e) {
-          this.callback(new Int32Array(this.response));
-        };
-        request.send();
-      } else {
-        $.ajax({
-          type: "GET",
-          url:
-            self.api_root +
-            "models/" +
-            self.mid +
-            "/tables/" +
-            self.aid +
-            "/arrays/0/" +
-            sortedUnsorted +
-            "-indices?rows=" +
-            row_string +
-            "&index=Index" +
-            sort,
-          async: false,
-          callback: callback,
-          success: function (data) {
-            this.callback(new Int32Array(data));
-          },
-        });
-      }
-    };
-
     self.get_indices = function (direction, rows, callback) {
       if (rows.length == 0) {
         callback([]);
@@ -583,55 +513,6 @@ $.widget("timeseries.table", {
 
     self.getLength = function () {
       return self.row_count;
-    };
-
-    self.getItem_old = function (index) {
-      var column_begin = 0;
-      var column_end = self.metadata["column-count"];
-      var page = Math.floor(index / self.page_size);
-      var page_begin = page * self.page_size;
-
-      if (!(page in self.pages)) {
-        var row_begin = page_begin;
-        var row_end = (page + 1) * self.page_size;
-
-        var sort = "";
-        if (self.sort_column !== null && self.sort_order !== null) {
-          sort = "&sort=" + self.sort_column + ":" + self.sort_order;
-        }
-
-        var rowsToRetrieve = self.retrieve_table_filter.slice(row_begin, row_end).join(",");
-
-        $.ajax({
-          type: "GET",
-          url:
-            self.api_root +
-            "models/" +
-            self.mid +
-            "/tables/" +
-            self.aid +
-            "/arrays/0/chunk?rows=" +
-            rowsToRetrieve +
-            "&columns=" +
-            column_begin +
-            "-" +
-            column_end +
-            "&index=Index" +
-            sort,
-          async: false,
-          success: function (data) {
-            self.pages[page] = data;
-          },
-          error: function (request, status, reason_phrase) {
-            console.log("error", request, status, reason_phrase);
-          },
-        });
-      }
-
-      var result = {};
-      for (var i = column_begin; i != column_end; ++i)
-        result[i] = self.pages[page].data[i][index - page_begin];
-      return result;
     };
 
     self.getItem = function (index) {

--- a/web-server/plugins/slycat-timeseries-model/js/timeseries.js
+++ b/web-server/plugins/slycat-timeseries-model/js/timeseries.js
@@ -37,6 +37,7 @@ import {
   setHiddenSimulations,
   setCurrentVIndex,
 } from "./services/dataSlice";
+import { COLUMN_LABELS } from "utils/ui-labels";
 
 export default function initialize_timeseries_model(
   dispatch,
@@ -359,7 +360,7 @@ export default function initialize_timeseries_model(
         lastRow +
         "&columns=" +
         parameters.column +
-        "&index=Index&sort=" +
+        "&index=" + encodeURIComponent(COLUMN_LABELS.index) + "&sort=" +
         lastColumn +
         ":ascending",
       async: true,

--- a/web-server/plugins/slycat-video-swarm/js/vs-ui.js
+++ b/web-server/plugins/slycat-video-swarm/js/vs-ui.js
@@ -30,6 +30,7 @@ import table_pane from "./vs-table.js";
 import movie_pane from "./vs-movies.js";
 import d3 from "d3";
 import control from "./vs-controls";
+import { COLUMN_LABELS } from "utils/ui-labels";
 // global parameters to set up movie-plex UI
 // -----------------------------------------
 
@@ -222,11 +223,11 @@ function model_loaded() {
 
       // Adding Index column to table_metadata and table_data
       table_metadata[0]["column-count"] = table_metadata[0]["column-count"] + 1;
-      table_metadata[0]["column-names"].push("Index");
+      table_metadata[0]["column-names"].push(COLUMN_LABELS.index);
       table_metadata[0]["column-types"].push("int64");
       table_metadata[0]["column-min"].push(0);
       table_metadata[0]["column-max"].push(table_metadata[0]["row-count"] - 1);
-      table_data[0]["column-names"].push("Index");
+      table_data[0]["column-names"].push(COLUMN_LABELS.index);
       table_data[0]["columns"].push(table_metadata[0]["column-count"] - 1);
       table_data[0]["data"].push(_.range(table_data[0]["rows"].length));
 

--- a/web-server/utils/ui-labels.ts
+++ b/web-server/utils/ui-labels.ts
@@ -24,3 +24,7 @@ export const REMOTE_AUTH_LABELS = {
     "Note: you may have tried too many times with bad credentials and have been suspended for the next few minutes.",
   authErrorUnauthorizedDescription: "Make sure the Hostname is entered correctly.",
 } as const;
+
+export const COLUMN_LABELS = {
+  index: "Row #",
+} as const;


### PR DESCRIPTION
… in multiple files for consistency

This makes the naming consistent across all our models and easy to change in the future.