### PR TITLE
refactor: add tooltips and encode column names in CCATable, timeserie…

### DIFF
--- a/web-server/plugins/slycat-cca/js/components/CCATable.tsx
+++ b/web-server/plugins/slycat-cca/js/components/CCATable.tsx
@@ -16,6 +16,7 @@ import SlickGridDataProvider from "./SlickGridDataProvider";
 
 import * as table_helpers from "js/slycat-table-helpers-react";
 import slycat_color_maps from "js/slycat-color-maps";
+import he from "he";
 
 class CCATable extends React.Component {
   constructor(props) {
@@ -48,10 +49,13 @@ class CCATable extends React.Component {
   }
 
   make_column = (column_index, header_class, cell_class) => {
+    const column_name = this.props.metadata["column-names"][column_index];
+    const encoded_column_name = he.encode(column_name);
     return {
       id: column_index,
       field: column_index,
-      name: this.props.metadata["column-names"][column_index],
+      name: encoded_column_name,
+      toolTip: column_name,
       sortable: false,
       headerCssClass: header_class,
       cssClass: cell_class,

--- a/web-server/plugins/slycat-timeseries-model/js/timeseries-table.js
+++ b/web-server/plugins/slycat-timeseries-model/js/timeseries-table.js
@@ -5,6 +5,7 @@
 
 import d3 from "d3";
 import * as chunker from "./chunker";
+import he from "he";
 
 import {
   SlickRowSelectionModel,
@@ -67,10 +68,13 @@ $.widget("timeseries.table", {
     }
 
     function make_column(column_index, header_class, cell_class) {
+      const column_name = self.options.metadata["column-names"][column_index];
+      const encoded_column_name = he.encode(column_name);
       var column = {
         id: column_index,
         field: column_index,
-        name: self.options.metadata["column-names"][column_index],
+        name: encoded_column_name,
+        toolTip: column_name,
         sortable: false,
         headerCssClass: header_class,
         cssClass: cell_class,

--- a/web-server/plugins/slycat-video-swarm/js/vs-table.js
+++ b/web-server/plugins/slycat-video-swarm/js/vs-table.js
@@ -36,6 +36,7 @@ window.Sortable = Sortable;
 
 import * as chunker from "js/chunker";
 import * as table_helpers from "js/slycat-table-helpers";
+import he from "he";
 
 $.widget("vs.table", {
   options: {
@@ -93,10 +94,13 @@ $.widget("vs.table", {
     }
 
     function make_column(column_index, header_class, cell_class) {
+      const column_name = self.options.metadata["column-names"][column_index];
+      const encoded_column_name = he.encode(column_name);
       return {
         id: column_index,
         field: column_index,
-        name: self.options.metadata["column-names"][column_index],
+        name: encoded_column_name,
+        toolTip: column_name,
         sortable: false,
         headerCssClass: header_class,
         cssClass: cell_class,


### PR DESCRIPTION
…s-table, and vs-table components

- Added HTML entity encoding for column names to prevent potential rendering issues.
- Updated column definitions to include tooltips with original column names for better user experience.