### PR TITLE
build: update lodash, uuid, and vtk.js versions in documentation files

### DIFF
--- a/docs/javascript_dependencies_in_node_modules.json
+++ b/docs/javascript_dependencies_in_node_modules.json
@@ -356,8 +356,8 @@
   },
   {
     "name": "lodash",
-    "version": "4.17.23",
-    "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz"
+    "version": "4.18.1",
+    "url": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz"
   },
   {
     "name": "lodash.debounce",
@@ -491,13 +491,13 @@
   },
   {
     "name": "uuid",
-    "version": "13.0.0",
-    "url": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz"
+    "version": "13.0.2",
+    "url": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz"
   },
   {
     "name": "vtk.js",
-    "version": "35.3.2",
-    "url": "https://registry.npmjs.org/vtk.js/-/vtk.js-35.3.2.tgz"
+    "version": "35.14.1",
+    "url": "https://registry.npmjs.org/vtk.js/-/vtk.js-35.14.1.tgz"
   },
   {
     "name": "vtk.js/node_modules/globalthis",

--- a/docs/javascript_dependencies_in_node_modules_columns.txt
+++ b/docs/javascript_dependencies_in_node_modules_columns.txt
@@ -69,7 +69,7 @@ jquery.scrollintoview                    1.9.4        https://registry.npmjs.org
 knockout                                 3.5.1        https://registry.npmjs.org/knockout/-/knockout-3.5.1.tgz                                               
 knockout-mapping                         2.6.0        https://registry.npmjs.org/knockout-mapping/-/knockout-mapping-2.6.0.tgz                               
 layout-jquery3                           1.8.5        https://registry.npmjs.org/layout-jquery3/-/layout-jquery3-1.8.5.tgz                                   
-lodash                                   4.17.23      https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz                                                 
+lodash                                   4.18.1       https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz                                                  
 lodash.debounce                          4.0.8        https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz                                 
 lodash.throttle                          4.0.1        https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.0.1.tgz                                 
 luxon                                    3.7.2        https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz                                                     
@@ -96,8 +96,8 @@ style-loader                             4.0.0        https://registry.npmjs.org
 three                                    0.183.2      https://registry.npmjs.org/three/-/three-0.183.2.tgz                                                   
 urijs                                    1.19.11      https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz                                                   
 use-sync-external-store                  1.6.0        https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz                 
-uuid                                     13.0.0       https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz                                                      
-vtk.js                                   35.3.2       https://registry.npmjs.org/vtk.js/-/vtk.js-35.3.2.tgz                                                  
+uuid                                     13.0.2       https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz                                                      
+vtk.js                                   35.14.1      https://registry.npmjs.org/vtk.js/-/vtk.js-35.14.1.tgz                                                 
 vtk.js/node_modules/globalthis           1.0.3        https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz                                           
 xmlbuilder2                              3.0.2        https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.0.2.tgz                                         
 zipinfo.js                               1.0.0        https://registry.npmjs.org/zipinfo.js/-/zipinfo.js-1.0.0.tgz                                           


### PR DESCRIPTION
I forgot to update our JS dependencies docs after the last couple package updates. Just brining them up to present.