### PR TITLE
Fix scatterplot axes not updating for string categorical filters

### DIFF
--- a/web-server/plugins/slycat-parameter-image/js/selectors.ts
+++ b/web-server/plugins/slycat-parameter-image/js/selectors.ts
@@ -617,16 +617,24 @@ export const selectXScale = createSelector(
   selectXScaleRange,
   selectXColumnType,
   selectXValues,
+  selectXValuesWithoutHidden,
   selectShowHistogram,
+  selectAutoScale,
   (
     xScaleType: string,
     xExtent: ExtentType,
     xScaleRange: ScaleRangeType,
     xColumnType: string | undefined,
     xValues,
+    xValuesWithoutHidden,
     selectShowHistogram,
+    autoScale,
   ): SlycatScaleType => {
-    return getScale(xScaleType, xExtent, xScaleRange, xColumnType, xValues, selectShowHistogram);
+    // For string columns, the domain is derived from the values array. When
+    // autoScale is on, use the filtered values so the axis reflects active
+    // filters (matching how getExtent handles numeric columns).
+    const values = autoScale ? xValuesWithoutHidden : xValues;
+    return getScale(xScaleType, xExtent, xScaleRange, xColumnType, values, selectShowHistogram);
   },
 );
 
@@ -651,16 +659,24 @@ export const selectYScale = createSelector(
   selectYScaleRange,
   selectYColumnType,
   selectYValues,
+  selectYValuesWithoutHidden,
   selectShowHistogram,
+  selectAutoScale,
   (
     yScaleType: string,
     yExtent: ExtentType,
     yScaleRange: ScaleRangeType,
     yColumnType: string,
     yValues,
+    yValuesWithoutHidden,
     selectShowHistogram,
+    autoScale,
   ): SlycatScaleType => {
-    return getScale(yScaleType, yExtent, yScaleRange, yColumnType, yValues, selectShowHistogram);
+    // For string columns, the domain is derived from the values array. When
+    // autoScale is on, use the filtered values so the axis reflects active
+    // filters (matching how getExtent handles numeric columns).
+    const values = autoScale ? yValuesWithoutHidden : yValues;
+    return getScale(yScaleType, yExtent, yScaleRange, yColumnType, values, selectShowHistogram);
   },
 );
 
@@ -680,16 +696,24 @@ export const selectVScale = createSelector(
   selectLegendScaleRange,
   selectVColumnType,
   selectVValues,
+  selectVValuesWithoutHidden,
   selectShowHistogram,
+  selectAutoScale,
   (
     vScaleType: string,
     vExtent: ExtentType,
     vScaleRange: ScaleRangeType,
     vColumnType: string,
     vValues,
+    vValuesWithoutHidden,
     showHistogram,
+    autoScale,
   ): SlycatScaleType => {
-    return getScale(vScaleType, vExtent, vScaleRange, vColumnType, vValues, showHistogram);
+    // For string columns, the domain is derived from the values array. When
+    // autoScale is on, use the filtered values so the axis reflects active
+    // filters (matching how getExtent handles numeric columns).
+    const values = autoScale ? vValuesWithoutHidden : vValues;
+    return getScale(vScaleType, vExtent, vScaleRange, vColumnType, values, showHistogram);
   },
 );
 


### PR DESCRIPTION
When filtering by a string categorical variable, points and color scales updated but X/Y/Color axis tick domains did not. Scale selectors now use filtered values (without hidden simulations) when auto-scale is on, matching how numeric axis extents already respect filters.