### PR TITLE
Stop CCA wizard from importing model ui.css onto other models.

### DIFF
--- a/web-server/plugins/slycat-cca/js/components/wizard-tabs/CCATableIngestion.tsx
+++ b/web-server/plugins/slycat-cca/js/components/wizard-tabs/CCATableIngestion.tsx
@@ -10,7 +10,6 @@ import {
   setScaleInputs,
 } from "../wizard-store/reducers/CCAWizardSlice";
 import { useHandleTableIngestionOnChange } from "../CCAWizardUtils";
-import '../../../css/ui.css';
 
 export const CCATableIngestion = (props: { hidden?: boolean }) => {
   const { hidden = false } = props;


### PR DESCRIPTION
Hey @Spurs20 I created this separate PR for a quick fix that I need to continue working on legend refactoring. This removes the CCA ui.css import that I think you added during CCA wizard work. I want to make sure it won't break anything that you did. It was causing issues because CCA css was being applied to other models. Let me know if this fix breaks anything for you and we can come up with a different way to approach this.